### PR TITLE
feat: Add JavaScript linting step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run linters
+        run: npm run lint
+
       - name: Run tests
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Pai Nai Dee Project",
   "main": "src/app.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^29.0.0"
+    "jest": "^29.0.0",
+    "eslint": "^8.57.0"
   }
 }


### PR DESCRIPTION
This commit adds a new step to the GitHub Actions CI workflow to run JavaScript linters using `npm run lint`.

The linting step is placed after dependency installation and before running tests to ensure code quality before testing.