### PR TITLE
Refactor: Improve HomePage, API env config, and ESLint hygiene

### DIFF
--- a/tourist-app/.gitignore
+++ b/tourist-app/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/tourist-app/src/api.ts
+++ b/tourist-app/src/api.ts
@@ -4,7 +4,7 @@ import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 // Replace this with your actual API endpoint.
 // For example: 'https://api.yourdomain.com/v1'
 // Or, if you are running a local backend: 'http://localhost:8000/api'
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/api'; // Fallback to /api if not set in .env
+const API_BASE_URL = process.env.REACT_APP_BASE_API_URL || '/api'; // Fallback to /api if not set in .env
 
 interface ApiError {
   message: string;

--- a/tourist-app/src/pages/HomePage.tsx
+++ b/tourist-app/src/pages/HomePage.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Typography, Container, Grid, Card, CardMedia, CardContent, CardActions, Button, Box, CircularProgress, Alert, Chip } from '@mui/material';
 import { Link } from 'react-router-dom';
-import { usePlaces, Place } from '../contexts/PlacesContext'; // Assuming Place type is exported
+import { Place } from '../contexts/PlacesContext'; // Assuming Place type is exported
 import { get } from '../api'; // Import the get function
 
 const HomePage: React.FC = () => {
-  // const { fetchPlaces } = usePlaces(); // We might not need this if we do a direct fetch
   const [featuredPlaces, setFeaturedPlaces] = useState<Place[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
- I verified MUI v5 Grid item usage in HomePage.tsx is correct, no TypeScript errors found.
- I removed the unused `usePlaces` import and related commented-out code from HomePage.tsx as it now uses a direct API call for featured places.
- I updated `api.ts` to use the `REACT_APP_BASE_API_URL` environment variable, consistent with existing `.env` and `.env.example` files.
- I added `.env` to `.gitignore` in `tourist-app/` to prevent local environment configurations from being committed.
- These changes align with guidelines and improve code clarity and configuration management.