### PR TITLE
feat: Configure ESLint, Prettier, CI, and READMEs for monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,22 @@
 # .github/workflows/ci.yml
-name: JavaScript CI
+name: Monorepo CI
 
 on:
   pull_request:
-    branches: [ main ] # Triggers on PRs targeting the main branch
+    branches: [main] # Triggers on PRs targeting the main branch
   workflow_dispatch: # Allows manual triggering
 
 jobs:
-  test:
+  frontend-ci:
+    name: Frontend CI (tourist-app)
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./tourist-app
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x] # Test on multiple Node.js versions
+        node-version: [20.x] # Using a recent LTS version
 
     steps:
       - name: Checkout repository
@@ -22,13 +26,59 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm' # Enable caching for npm dependencies
+          cache: 'npm'
+          cache-dependency-path: tourist-app/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci # Use ci for cleaner installs
+
+      - name: Run linters
+        run: npm run lint
 
       - name: Run tests
-        run: npm test
+        run: npm test -- --watchAll=false # Ensure non-interactive mode
 
-      - name: Show status message - Tests
-        run: echo "JavaScript tests completed successfully."
+      - name: Build application
+        run: npm run build
+
+      - name: Show status message - Frontend
+        run: echo "Frontend CI checks completed successfully."
+
+  backend-ci:
+    name: Backend CI (wanderlust_guide)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./wanderlust_guide
+
+    strategy:
+      matrix:
+        python-version: ['3.10'] # Specify Python version
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('wanderlust_guide/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests (pytest)
+        run: pytest
+
+      - name: Show status message - Backend
+        run: echo "Backend CI checks completed successfully."

--- a/README.md
+++ b/README.md
@@ -1,34 +1,120 @@
-# Pai Nai Dee
+# Pai Nai Dee (Where to Go?) - Monorepo
 
-## คำอธิบายโปรเจกต์
-Pai Nai Dee คือแอปพลิเคชัน/เว็บไซต์/ระบบ (โปรดระบุประเภทโปรเจกต์ของคุณ) ที่ช่วยให้ผู้ใช้สามารถค้นหา/เปรียบเทียบ/แนะนำสถานที่ท่องเที่ยว ร้านอาหาร หรือกิจกรรมต่างๆ ได้อย่างสะดวกและรวดเร็ว (โปรดปรับแก้ให้ตรงกับวัตถุประสงค์ของโปรเจกต์คุณ)
+This project is a monorepo containing the "Pai Nai Dee" application, which helps users discover tourist attractions, plan trips, and more. It's composed of a React frontend and a Python backend/utility set.
 
-## วิธีติดตั้ง/ใช้งาน
+## Project Structure
 
-1. Clone โปรเจกต์นี้
-   ```bash
-   git clone https://github.com/Gotji253/Pai_Nai_Dee.git
-   cd Pai_Nai_Dee
-   ```
-2. ติดตั้ง dependency (ระบุเครื่องมือที่ใช้ เช่น pip, npm, yarn ฯลฯ)
-   ```bash
-   # ตัวอย่างสำหรับ Python
-   pip install -r requirements.txt
-   ```
-3. เริ่มต้นใช้งาน
-   ```bash
-   # ตัวอย่างสำหรับรันแอป
-   python app.py
-   ```
-   (หากมีขั้นตอนอื่น เช่น ตั้งค่า environment variables หรือ config เพิ่มเติม โปรดระบุ)
+The repository is organized as follows:
 
-## ฟีเจอร์หลัก
-- ค้นหาสถานที่ท่องเที่ยว/ร้านอาหาร/กิจกรรม (โปรดระบุฟีเจอร์จริงของโปรเจกต์)
-- เปรียบเทียบข้อมูลแต่ละสถานที่
-- ระบบรีวิว/ให้คะแนน
-- แผนที่แสดงตำแหน่ง
-- บันทึกสถานที่โปรด
+-   **`tourist-app/`**: Contains the React + TypeScript frontend application.
+    -   Uses Create React App, Material-UI, and Axios.
+-   **`wanderlust_guide/`**: Contains the Python backend services and utilities.
+    -   Currently includes utility functions and basic search/filter logic.
+    -   Uses `pytest` for testing.
+-   **`.github/`**: Contains GitHub Actions CI/CD workflows.
+
+## Getting Started
+
+Below are instructions for setting up and running each part of the project.
+
+### 1. Frontend (`tourist-app/`)
+
+**Prerequisites:**
+*   Node.js (v18.x or v20.x recommended)
+*   npm (usually comes with Node.js)
+
+**Setup & Running:**
+
+1.  **Navigate to the frontend directory:**
+    ```bash
+    cd tourist-app
+    ```
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+3.  **Run the development server:**
+    ```bash
+    npm start
+    ```
+    The application will typically be available at `http://localhost:3000`.
+
+4.  **Run tests:**
+    ```bash
+    npm test
+    ```
+
+5.  **Lint and format:**
+    ```bash
+    npm run lint
+    npm run format
+    ```
+
+**Environment Variables:**
+*   The frontend might require environment variables (e.g., API keys or backend URLs). Create a `.env` file in the `tourist-app/` directory by copying from `tourist-app/.env.example` and fill in the required values.
+
+### 2. Backend (`wanderlust_guide/`)
+
+**Prerequisites:**
+*   Python (v3.9+ recommended)
+*   pip (Python package installer)
+
+**Setup & Running:**
+
+1.  **Navigate to the backend directory:**
+    ```bash
+    cd wanderlust_guide
+    ```
+2.  **Create a virtual environment (recommended):**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+    ```
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+4.  **Run tests:**
+    ```bash
+    pytest
+    ```
+5.  **Run the main script (if applicable for local testing/utility):**
+    The backend currently consists of utilities and doesn't run a persistent server. You can execute scripts like `main.py` if needed for specific tasks:
+    ```bash
+    python app/main.py
+    ```
+
+**Environment Variables:**
+*   If the backend requires any environment variables, ensure they are set in your shell or via a `.env` file if a library like `python-dotenv` is added later.
+
+## Tech Stack
+
+**Frontend (`tourist-app/`):**
+*   React
+*   TypeScript
+*   Material-UI (MUI)
+*   React Router
+*   Axios
+*   ESLint & Prettier
+
+**Backend (`wanderlust_guide/`):**
+*   Python
+*   Pytest
+
+## CI/CD
+
+*   **Continuous Integration (CI):** GitHub Actions are configured in `.github/workflows/ci.yml`.
+    *   **Frontend:** On every pull request to `main`, the CI installs Node.js dependencies, runs linters, executes tests, and performs a production build.
+    *   **Backend:** On every pull request to `main`, the CI installs Python dependencies and runs `pytest`.
+*   **Deployment:**
+    *   **Frontend (`tourist-app/`):** Can be built using `npm run build` (output in `tourist-app/build/`). This static output can be deployed to services like Vercel, Netlify, AWS S3/CloudFront, Firebase Hosting, etc.
+    *   **Backend (`wanderlust_guide/`):** Deployment strategy depends on the nature of the backend. If it evolves into a web service (e.g., using Flask/FastAPI), it can be deployed to platforms like Render, Heroku, AWS Elastic Beanstalk, Google Cloud Run, or Dockerized and run on various container services. Currently, it's a set of utilities.
+
+## Contributing
+
+Please ensure your code adheres to the linting and formatting standards. Update tests and documentation as needed.
 
 ---
 
-หากต้องการให้เจาะจงกับเทคโนโลยีหรือฟีเจอร์อื่น ๆ สามารถระบุรายละเอียดเพิ่มได้เลยครับ
+*Original Thai description (for reference):*
+> Pai Nai Dee คือแอปพลิเคชัน/เว็บไซต์/ระบบ (โปรดระบุประเภทโปรเจกต์ของคุณ) ที่ช่วยให้ผู้ใช้สามารถค้นหา/เปรียบเทียบ/แนะนำสถานที่ท่องเที่ยว ร้านอาหาร หรือกิจกรรมต่างๆ ได้อย่างสะดวกและรวดเร็ว (โปรดปรับแก้ให้ตรงกับวัตถุประสงค์ของโปรเจกต์คุณ)

--- a/tourist-app/.eslintrc.json
+++ b/tourist-app/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": [
+    "react-app",
+    "react-app/jest",
+    "plugin:prettier/recommended"
+  ],
+  "plugins": ["prettier"],
+  "rules": {
+    "prettier/prettier": "warn",
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
+  }
+}

--- a/tourist-app/.prettierrc.json
+++ b/tourist-app/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "jsxSingleQuote": true
+}

--- a/tourist-app/README.md
+++ b/tourist-app/README.md
@@ -1,46 +1,91 @@
-# Getting Started with Create React App
+# Tourist App (Frontend)
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project is the frontend for the "Pai Nai Dee" application, bootstrapped with [Create React App](https://github.com/facebook/create-react-app). It allows users to discover tourist attractions, plan trips, and more.
+
+## Tech Stack Overview
+
+*   **React**: Core UI library.
+*   **TypeScript**: For static typing and improved developer experience.
+*   **Material-UI (MUI)**: UI component library for a consistent and modern look.
+*   **React Router DOM**: For client-side routing.
+*   **Axios**: For making HTTP requests to the backend API.
+*   **ESLint**: For code linting to maintain code quality.
+*   **Prettier**: For code formatting to ensure consistent style.
 
 ## Available Scripts
 
-In the project directory, you can run:
+In the `tourist-app/` directory, you can run:
 
 ### `npm start`
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+Runs the app in development mode.\
+Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+The page will reload if you make edits. You will also see any lint errors in the console.
 
 ### `npm test`
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Launches the test runner in interactive watch mode.
+See the Create React App section on [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+For CI environments, tests are typically run with `npm test -- --watchAll=false`.
 
 ### `npm run build`
 
 Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
+It correctly bundles React in production mode and optimizes the build for the best performance. The build is minified, and the filenames include hashes.
 Your app is ready to be deployed!
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+### `npm run lint`
+
+Runs ESLint to analyze the code for potential errors and style issues.
+```bash
+npm run lint
+```
+
+### `npm run format`
+
+Formats the code using Prettier.
+```bash
+npm run format
+```
 
 ### `npm run eject`
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
 If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+## Environment Variables
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+The application uses environment variables for configuration, especially for connecting to the backend API.
+
+1.  Create a `.env` file in the `tourist-app/` root directory by copying the example file:
+    ```bash
+    cp .env.example .env
+    ```
+2.  Modify the `.env` file with your specific configuration values.
+    For example:
+    ```env
+    REACT_APP_BASE_API_URL=http://localhost:8000/api
+    # REACT_APP_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
+    ```
+    Variables must be prefixed with `REACT_APP_` to be embedded in the build by Create React App.
+
+## Deployment
+
+After building the application with `npm run build`, the `build/` directory will contain all the static assets for your application.
+
+You can deploy this `build` folder to various static site hosting services, such as:
+
+*   **Vercel**: Offers seamless deployment for React projects. Connect your Git repository for automatic deployments.
+*   **Netlify**: Similar to Vercel, provides CI/CD and hosting for static sites.
+*   **Firebase Hosting**: A good option if you're already using other Firebase services.
+*   **AWS S3 & CloudFront**: For a more traditional cloud setup.
+*   **GitHub Pages**: Suitable for simple projects and personal sites.
+
+Ensure your hosting service is configured to serve `index.html` for all route requests if you are using client-side routing with React Router. This is often referred to as a "single-page application" (SPA) rewrite rule.
 
 ## Learn More
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+*   [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started)
+*   [React documentation](https://reactjs.org/)
+*   [Material-UI documentation](https://mui.com/material-ui/getting-started/)
+*   [TypeScript documentation](https://www.typescriptlang.org/docs/)

--- a/tourist-app/package-lock.json
+++ b/tourist-app/package-lock.json
@@ -28,6 +28,11 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.5.1",
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3425,6 +3430,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -7729,6 +7747,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -7944,6 +7978,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
+      "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -8427,6 +8492,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -14066,6 +14138,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -16478,6 +16579,22 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
+    },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",

--- a/tourist-app/package.json
+++ b/tourist-app/package.json
@@ -28,17 +28,13 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint . --ext .ts,.tsx",
+    "format": "prettier --write ."
   },
   "jest": {
     "transformIgnorePatterns": [
       "/node_modules/(?!axios)/"
-    ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
     ]
   },
   "browserslist": {
@@ -52,5 +48,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.5.1",
+    "prettier": "^3.6.2"
   }
 }

--- a/wanderlust_guide/requirements.txt
+++ b/wanderlust_guide/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=7.0.0  # For running tests
+# Add other backend dependencies here if any are introduced later
+# e.g., Flask, FastAPI, requests, numpy, pandas, etc.


### PR DESCRIPTION
- Added ESLint and Prettier to tourist-app with scripts and configs.
- Created requirements.txt for wanderlust_guide and ensured pytest compatibility.
- Updated GitHub Actions CI workflow (.github/workflows/ci.yml) to support separate frontend and backend jobs with caching, linting, testing, and building.
- Revised root README.md with monorepo structure, setup instructions for both apps, tech stack, and CI/deployment details.
- Enhanced tourist-app/README.md with lint/format scripts, env var info, and deployment guidance.