### PR TITLE
Fix: Resolve TS2769 error in FavoritesPage Grid item

### DIFF
--- a/tourist-app/src/pages/FavoritesPage.tsx
+++ b/tourist-app/src/pages/FavoritesPage.tsx
@@ -46,7 +46,7 @@ const FavoritesPage: React.FC = () => {
       ) : (
         <Grid container spacing={3}>
           {favoritePlaces.map(place => (
-            <Grid item xs={12} sm={6} md={4} key={place.id}>
+            <Grid item component="div" xs={12} sm={6} md={4} key={place.id}>
               <Card sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
                  {place.image && (
                     <CardMedia


### PR DESCRIPTION
Added `component="div"` to the MUI Grid item in `FavoritesPage.tsx` to resolve the TypeScript error TS2769 "No overload matches this call". This explicitly sets the underlying component for the Grid item, aiding TypeScript in correctly inferring prop types.